### PR TITLE
onProgress機能の追加

### DIFF
--- a/__test__/main.spec.ts
+++ b/__test__/main.spec.ts
@@ -17,6 +17,7 @@ test('promise serial test',async () => {
         });
     };
 
+
     const values = ['a', 'b', 'c', 'd', 'e', 'f'];
     const result = await promiseSerial(values.map(waitForTest).map((cb) => call(cb, Math.random() * 200))).value;
     expect(result).toEqual(values);

--- a/__test__/main.spec.ts
+++ b/__test__/main.spec.ts
@@ -8,7 +8,6 @@ test('util test', async () => {
 });
 
 test('promise serial test',async () => {
-
     const waitForTest = (returnValue: string) => async (waitTime: number) => {
         return new Promise(resolve => {
             setTimeout(() => {
@@ -17,8 +16,15 @@ test('promise serial test',async () => {
         });
     };
 
-
     const values = ['a', 'b', 'c', 'd', 'e', 'f'];
-    const result = await promiseSerial(values.map(waitForTest).map((cb) => call(cb, Math.random() * 200))).value;
+    const result = await promiseSerial(values.map(waitForTest).map((cb) => call(cb, Math.random() * 200)), {
+        onProgress: (progress, index) => {
+            const progressValue = 1 / values.length;
+            const containResult = new Array(values.length).fill(0).map((_, index) => {
+                return (index + 1) * progressValue;
+            });
+            expect(progress).toBeCloseTo(containResult[index]);
+        },
+    }).value;
     expect(result).toEqual(values);
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,10 +13,13 @@ interface PromiseSerialResult<T extends readonly unknown[] | []> {
 }
 
 // TODO 随時追加
-interface PromiseSerialOptions {
+interface PromiseSerialOptions<T> {
+    onProgress?: (value: number, result: T) => void
 }
 
-export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {}: PromiseSerialOptions = {}): PromiseSerialResult<T[]> => {
+export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
+    onProgress
+}: PromiseSerialOptions<T> = {}): PromiseSerialResult<T[]> => {
     let isCancel = false;
 
     const main = async () => {
@@ -24,6 +27,7 @@ export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {}: P
         for (let i = 0; i < values.length; i ++ ) {
             try {
                 const result = await values[i]();
+                if (onProgress != null) onProgress(i / values.length, result);
                 if (isCancel) throw new CannceledError<T>(results);
                 results.push(result);
             } catch (err) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,11 +1,4 @@
 import { CannceledError } from './errors';
-/**
- * Promiseを直列実行させるための関数
- * @param values 同期処理をするPromise群
- * @returns result.value Promiseを返却
- * @returns result.cancel() 実行時にキャンセル
- * @returns result.progress() 現在の進捗 0-1
- */
 
 interface PromiseSerialResult<T extends readonly unknown[] | []> {
     value: Promise<T>;
@@ -14,9 +7,17 @@ interface PromiseSerialResult<T extends readonly unknown[] | []> {
 
 // TODO 随時追加
 interface PromiseSerialOptions<T> {
-    onProgress?: (value: number, result: T) => void
+    onProgress?: (value: number, index: number, result: T) => void
 }
 
+/**
+ * Promiseを直列実行させるための関数
+ * @param values 同期処理をするPromise群
+ * @param options.onProgress 進行状況を返却するコールバックの定義
+ * @returns result.value Promiseを返却
+ * @returns result.cancel() 実行時にキャンセル
+ * @returns result.progress() 現在の進捗 0-1
+ */
 export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
     onProgress
 }: PromiseSerialOptions<T> = {}): PromiseSerialResult<T[]> => {
@@ -27,7 +28,7 @@ export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
         for (let i = 0; i < values.length; i ++ ) {
             try {
                 const result = await values[i]();
-                if (onProgress != null) onProgress(i / values.length, result);
+                if (onProgress != null) onProgress((i + 1) / values.length, i, result);
                 if (isCancel) throw new CannceledError<T>(results);
                 results.push(result);
             } catch (err) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,2 @@
+
 export const call = <T extends (...args: any[]) => any>(cb: T, ...data: Parameters<T>) => (): ReturnType<T> => cb(...data);


### PR DESCRIPTION
## 概要

オプション値でonProgressを定義し、進行状況を取得できるようにした

## 仕様

```ts
onProgress?: (value: number, index: number, result: T) => void
```

テストケース https://github.com/ArakiTakaki/promise-serial/blob/c3a61e590ee400082971fa1b01a78e112e733c60/__test__/main.spec.ts#L20-L28

実装 https://github.com/ArakiTakaki/promise-serial/blob/5df77460515e76ca3e705a81aff6bd28d755a71c/src/core.ts#L31


