### PR TITLE
Promiseのキャンセルに、時間を持たせる

### DIFF
--- a/__test__/main.spec.ts
+++ b/__test__/main.spec.ts
@@ -1,11 +1,4 @@
-import { promiseSerial, call } from '../src/main';
-
-test('util test', async () => {
-    const arg = 'result'
-    const exampleCallTest = (bar: string) => bar;
-    const result = call(exampleCallTest, arg);
-    expect(result()).toBe(arg);
-});
+import { promiseSerial } from '../src/main';
 
 const waitForTest = (returnValue: string) => async (waitTime: number) => {
     return new Promise(resolve => {

--- a/__test__/main.spec.ts
+++ b/__test__/main.spec.ts
@@ -1,4 +1,5 @@
 import { promiseSerial } from '../src/main';
+import { call } from '../src/utils';
 
 const waitForTest = (returnValue: string) => async (waitTime: number) => {
     return new Promise(resolve => {
@@ -8,24 +9,41 @@ const waitForTest = (returnValue: string) => async (waitTime: number) => {
     });
 };
 
-test('promise serial test',async () => {
-    const values = ['a', 'b', 'c', 'd', 'e', 'f'];
-    const result = await promiseSerial(values.map(waitForTest).map((cb) => call(cb, Math.random() * 200)), {
-        onProgress: (progress, index) => {
-            const progressValue = 1 / values.length;
-            const containResult = new Array(values.length).fill(0).map((_, index) => {
-                return (index + 1) * progressValue;
-            });
-            expect(progress).toBeCloseTo(containResult[index]);
-        },
-    }).value;
-    expect(result).toEqual(values);
-});
-
-test('promise serial timeout test', async () => {
-    const values = ['a', 'b', 'c', 'd', 'e', 'f'];
-    const result = promiseSerial(values.map(waitForTest).map((cb) => call(cb, Math.random() * 1000)), {
-        timeout: 100,
+describe('promise serial', () => {
+    it('basic', async () => {
+        const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+        const result = await promiseSerial(values.map(waitForTest).map((cb, index) => call(cb, 100 * index)), {
+            onProgress: (progress, index) => {
+                const progressValue = 1 / values.length;
+                const containResult = new Array(values.length).fill(0).map((_, index) => {
+                    return (index + 1) * progressValue;
+                });
+                expect(progress).toBeCloseTo(containResult[index]);
+            },
+        }).value;
+        expect(result).toEqual(values);
     });
-    await expect(result.value).rejects.toThrowError();
+
+    it('timeout', async () => {
+        const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+        const result = promiseSerial(values.map(waitForTest).map((cb, index) => call(cb, 100 * index)), {
+            timeout: 100,
+        });
+        expect(result.value).rejects.toThrowError();
+    });
+
+    it('canncel not throw', async () => {
+        const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+        const answer = ['a'];
+        const result = promiseSerial(values.map(waitForTest).map((cb) => call(cb, 100)), {
+            timeout: Infinity,
+            isNotCancelledThrow: true,
+        });
+
+        setTimeout(() => {
+            expect(result.cancel()).resolves.toEqual(answer);
+        }, 120);
+
+        await expect(result.value).resolves.toEqual(answer);
+    });
 });

--- a/__test__/utils.spec.ts
+++ b/__test__/utils.spec.ts
@@ -8,20 +8,34 @@ test('call test', async () => {
 });
 
 const waitFor = (time: number) => new Promise((resolve) => setTimeout(resolve, time));
-test('debounce executed number', async () => {
-    let count = 0;
-    const exec = debounce(() => {
-        count ++;
-    }, 100);
-    exec.exec();
-    exec.exec();
-    exec.exec();
-    exec.exec();
-    exec.exec();
-    await waitFor(110);
-    exec.exec();
-    await waitFor(110);
-    expect(count).toBe(2);
+describe('debounce', () => {
+    test('basic', async () => {
+        let count = 0;
+        const exec = debounce(() => {
+            count ++;
+        }, 100);
+        exec.exec();
+        exec.exec();
+        exec.exec();
+        exec.exec();
+        exec.exec();
+        await waitFor(110);
+        exec.exec();
+        await waitFor(110);
+        expect(count).toBe(2);
+    });
+
+    test('infinity', async () => {
+        let count = 0;
+        const execDebounce = debounce(() => {
+            count ++;
+        }, Infinity);
+        setTimeout(() => {
+            execDebounce.cancel();
+            expect(count).toBe(0);
+        });
+        execDebounce.exec();
+    });
 });
 
 describe('event promise test', () => {
@@ -48,5 +62,18 @@ describe('event promise test', () => {
             }, 100);
             await event.promise;
         }).rejects.toThrowError();
+    });
+
+    it('timeout', async () => {
+        const answer = 10;
+        const event = eventPromise<number>({
+            timeout: Infinity,
+        });
+
+        setTimeout(() => {
+            event.resolveEvent(answer);
+        }, 100);
+
+        expect(event.promise).resolves.toBe(answer);
     });
 });

--- a/__test__/utils.spec.ts
+++ b/__test__/utils.spec.ts
@@ -1,5 +1,4 @@
-import { debounce } from '../src/utils';
-
+import { debounce, eventPromise } from '../src/utils';
 
 const waitFor = (time: number) => new Promise((resolve) => setTimeout(resolve, time));
 test('debounce executed number', async () => {
@@ -16,4 +15,31 @@ test('debounce executed number', async () => {
     exec.exec();
     await waitFor(110);
     expect(count).toBe(2);
+});
+
+describe('event promise test', () => {
+    it('resolve', async () => {
+        const answer = 10;
+        const event = eventPromise<number>({
+            timeout: 100,
+        });
+        setTimeout(() => {
+            event.resolveEvent(answer);
+        }, 10);
+        const result = await event.promise;
+        expect(result).toBe(answer);
+    });
+
+    it('reject', async () => {
+        await expect(async () => {
+            const answer = 10;
+            const event = eventPromise<number>({
+                timeout: 10,
+            });
+            setTimeout(() => {
+                event.resolveEvent(answer);
+            }, 100);
+            await event.promise;
+        }).rejects.toThrowError();
+    });
 });

--- a/__test__/utils.spec.ts
+++ b/__test__/utils.spec.ts
@@ -1,4 +1,11 @@
-import { debounce, eventPromise } from '../src/utils';
+import { debounce, eventPromise, call } from '../src/utils';
+
+test('call test', async () => {
+    const arg = 'result'
+    const exampleCallTest = (bar: string) => bar;
+    const result = call(exampleCallTest, arg);
+    expect(result()).toBe(arg);
+});
 
 const waitFor = (time: number) => new Promise((resolve) => setTimeout(resolve, time));
 test('debounce executed number', async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_TIMEOUT_NUMBER = 2 ** 31 - 1;

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,15 +1,16 @@
 import { CannceledError } from './errors';
-import { debounce } from './utils';
+import { debounce, eventPromise } from './utils';
 
 interface PromiseSerialResult<T extends readonly unknown[] | []> {
     value: Promise<T>;
-    cancel: () => void;
+    cancel: () => Promise<T>;
 }
 
 // TODO 随時追加
 interface PromiseSerialOptions<T> {
     onProgress?: (value: number, index: number, result: T) => void
     timeout?: number;
+    isNotCancelledThrow?: boolean;
 }
 
 /**
@@ -17,6 +18,7 @@ interface PromiseSerialOptions<T> {
  * @param values 同期処理をするPromise群
  * @param options.onProgress 進行状況を返却するコールバックの定義
  * @param options.timeout 各イベントのタイムアウト期間 (初期値：50秒)
+ * @param options.isNotCancelledThrow canncel時にthrowするかどうか
  * @returns result.value Promiseを返却
  * @returns result.cancel() 実行時にキャンセル
  * @returns result.progress() 現在の進捗 0-1
@@ -24,10 +26,12 @@ interface PromiseSerialOptions<T> {
 export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
     onProgress,
     timeout = 50000,
+    isNotCancelledThrow = false,
 }: PromiseSerialOptions<T> = {}): PromiseSerialResult<T[]> => {
     let isCancel = false;
-
     const results: T[] = [];
+    const cancelledPromise = eventPromise<T[]>();
+    cancelledPromise.promise.catch(() => {});
 
     const timeoverEvent = debounce(() => {
         isCancel = true;
@@ -40,13 +44,19 @@ export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
             try {
                 const result = await values[i]();
                 if (onProgress != null) onProgress((i + 1) / values.length, i, result);
-                if (isCancel) throw new CannceledError<T>(results);
+                if (isCancel) {
+                    cancelledPromise.resolveEvent(results);
+                    timeoverEvent.cancel();
+                    if (isNotCancelledThrow) return results;
+                    throw new CannceledError<T>(results);
+                }
                 results.push(result);
             } catch (err) {
                 throw err;
             }
         }
 
+        cancelledPromise.cancel();
         timeoverEvent.cancel();
         return results;
     };
@@ -55,6 +65,7 @@ export const promiseSerial = <T extends Promise<any>>(values: (() => T)[], {
         value: main(),
         cancel: () => {
             isCancel = true;
+            return cancelledPromise.promise;
         },
     };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,56 @@
 
 export const call = <T extends (...args: any[]) => any>(cb: T, ...data: Parameters<T>) => (): ReturnType<T> => cb(...data);
 
+interface EventPromiseOption {
+  timeout?: number;
+}
+
+export const eventPromise = <T>({
+  timeout = 500000,
+}: EventPromiseOption = {}) => {
+  const timeoverEvent = debounce((cb: Function) => {
+    cb();
+  }, timeout);
+
+  let resolveEvent: ((value: T) => void) = () => {
+    throw new Error('not defined event');
+  };
+
+  let rejectEvent: ((error: Error) => void) = () => {
+    throw new Error('not defined event');
+  };
+
+  const promise = new Promise((resolve, reject) => {
+    let isFinish = false;
+
+    timeoverEvent.exec(() => {
+      if (isFinish) return;
+      const error = new Error('event promise is timeover');
+      error.name = 'EventPromiseError';
+      isFinish = true;
+      reject(error);
+    });
+    resolveEvent = (value: T) => {
+      if (isFinish) return;
+      timeoverEvent.cancel();
+      resolve(value);
+      isFinish = true;
+    };
+
+    rejectEvent = (error: Error) => {
+      if (isFinish) return;
+      reject(error);
+      isFinish = true;
+    };
+  });
+
+  return {
+    promise,
+    resolveEvent,
+    rejectEvent,
+  };
+};
+
 /**
  * イベントを呼び出し後、次のイベントまで指定した時間が経過するまではイベントを発生させない処理。
  * @param callback

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { MAX_TIMEOUT_NUMBER } from './constants';
 
 export const call = <T extends (...args: any[]) => any>(cb: T, ...data: Parameters<T>) => (): ReturnType<T> => cb(...data);
 
@@ -8,6 +9,7 @@ interface EventPromiseOption {
 export const eventPromise = <T>({
   timeout = 500000,
 }: EventPromiseOption = {}) => {
+
   const timeoverEvent = debounce((cb: Function) => {
     cb();
   }, timeout);
@@ -16,31 +18,36 @@ export const eventPromise = <T>({
     throw new Error('not defined event');
   };
 
-  let rejectEvent: ((error: Error) => void) = () => {
+  let rejectEvent: ((error?: Error) => void) = () => {
     throw new Error('not defined event');
   };
 
-  const promise = new Promise((resolve, reject) => {
+  const promise = new Promise<T>((resolve, reject) => {
     let isFinish = false;
 
     timeoverEvent.exec(() => {
       if (isFinish) return;
+      isFinish = true;
+
       const error = new Error('event promise is timeover');
       error.name = 'EventPromiseError';
-      isFinish = true;
       reject(error);
     });
+
     resolveEvent = (value: T) => {
       if (isFinish) return;
-      timeoverEvent.cancel();
-      resolve(value);
       isFinish = true;
+      timeoverEvent.cancel();
+
+      resolve(value);
     };
 
-    rejectEvent = (error: Error) => {
+    rejectEvent = (error?: Error) => {
       if (isFinish) return;
-      reject(error);
       isFinish = true;
+      timeoverEvent.cancel();
+
+      reject(error);
     };
   });
 
@@ -48,6 +55,7 @@ export const eventPromise = <T>({
     promise,
     resolveEvent,
     rejectEvent,
+    cancel: (error: Error = new Error('not thowr')) => rejectEvent(error),
   };
 };
 
@@ -65,7 +73,7 @@ export const debounce = <T extends (...args: any[]) => any>(func: T, wait: numbe
     clearTimeout(cancelToken);
     cancelToken = setTimeout(() => {
       func(...args);
-    }, wait);
+    }, Math.min(wait, MAX_TIMEOUT_NUMBER));
   }
   return {
     exec: callback,


### PR DESCRIPTION
## 該当Issue

- #3

## 概要

PromiseのCancel時にハンドリングができるよう、仕様を修正。

## 仕様

### ソース

https://github.com/ArakiTakaki/promise-serial/blob/01d1c68137393337039191f913482debcfeb49e6/src/core.ts#L4-L7

### テスト

https://github.com/ArakiTakaki/promise-serial/blob/01d1c68137393337039191f913482debcfeb49e6/__test__/main.spec.ts#L35-L48

## ひとこと

なんか、setTimeoutは32ビット数値じゃないと0秒発火するみたい。
Inifinity入れるとバグるから、意味的に正しくなるように変更せざるを得なくて面倒臭かった
